### PR TITLE
Improvement/base image update

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -16,9 +16,8 @@ jobs:
           export EXTRA_TAG="-premerge-$(git rev-parse --short HEAD)"
           docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" || echo "Only repo editors can push images"
           images=( 
-            'go:1.14'
-            'go-init:1.14'
-            'go-init:1.13'
+            'go:1.17'
+            'go-init:1.17'
           )
           for image in "${images[@]}"; do
             docker tag kubeless/${image} ciscom31/${image}${EXTRA_TAG}

--- a/stable/golang/Dockerfile
+++ b/stable/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb:jessie
+FROM bitnami/minideb:stretch
 
 RUN install_packages ca-certificates
 

--- a/stable/golang/Dockerfile.1.17.init
+++ b/stable/golang/Dockerfile.1.17.init
@@ -1,0 +1,11 @@
+FROM golang:1.17
+
+# Prepare function environment
+COPY /compile-function.sh /
+
+# Install controller
+COPY server /server
+RUN  chown 1000:1000 /server -R
+WORKDIR /server
+
+USER 1000

--- a/stable/golang/Makefile
+++ b/stable/golang/Makefile
@@ -1,23 +1,23 @@
 # Init images
 init-image-1.17:
-	docker build --no-cache -f Dockerfile.1.17.init -t dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go-init:iwo-0.0.10 .
+	docker build --no-cache -f Dockerfile.1.17.init -t kubeless/go-init:1.17 .
 
 init-image: init-image-1.17
 
 # Runtime images
 runtime-image-1.17:
-	docker build --no-cache -f Dockerfile -t dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go:iwo-0.0.10 .
+	docker build --no-cache -f Dockerfile -t kubeless/go:1.17 .
 
 runtime-image: runtime-image-1.17
 
 # Push images
 push-init-1.17:
-	docker push dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go-init:iwo-0.0.10
+	docker push kubeless/go-init:1.17
 
 push-init: push-init-1.17
 
 push-runtime-1.17:
-    docker push dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go:iwo-0.0.10
+    docker push kubeless/go:1.17
 
 push-runtime: push-runtime-1.17
 

--- a/stable/golang/Makefile
+++ b/stable/golang/Makefile
@@ -1,10 +1,4 @@
 # Init images
-init-image-1.13:
-	docker build --no-cache -f Dockerfile.1.13.init -t kubeless/go-init:1.13 .
-
-init-image-1.14:
-	docker build --no-cache -f Dockerfile.1.14.init -t kubeless/go-init:1.14 .
-
 init-image-1.17:
 	docker build --no-cache -f Dockerfile.1.17.init -t dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go-init:iwo-0.0.10 .
 
@@ -17,16 +11,10 @@ runtime-image-1.17:
 runtime-image: runtime-image-1.17
 
 # Push images
-push-init-1.13:
-	docker push kubeless/go-init:1.13
-
 push-init-1.17:
 	docker push dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go-init:iwo-0.0.10
 
 push-init: push-init-1.17
-
-push-runtime-1.14:
-	docker push kubeless/go:1.14
 
 push-runtime-1.17:
     docker push dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go:iwo-0.0.10
@@ -42,14 +30,14 @@ deploy: get-go get-go-custom-port timeout-go get-go-deps post-go
 test: get-go-verify get-go-custom-port-verify timeout-go-verify get-go-deps-verify post-go-verify
 
 get-go:
-	kubeless function deploy get-go --runtime go1.14 --handler handler.Foo --from-file examples/helloget.go
+	kubeless function deploy get-go --runtime go1.17 --handler handler.Foo --from-file examples/helloget.go
 
 get-go-verify:
 	kubectl rollout status deployment/get-go && sleep 2
 	kubeless function call get-go | egrep Hello.world
 
 get-go-custom-port:
-	kubeless function deploy get-go-custom-port --runtime go1.14 --handler helloget.Foo --from-file examples/helloget.go --port 8083
+	kubeless function deploy get-go-custom-port --runtime go1.17 --handler helloget.Foo --from-file examples/helloget.go --port 8083
 
 get-go-custom-port-verify:
 	kubectl rollout status deployment/get-go-custom-port && sleep 2
@@ -59,7 +47,7 @@ get-go-custom-port-verify:
 timeout-go:
 	$(eval TMPDIR := $(shell mktemp -d))
 	printf 'package kubeless\nimport "github.com/kubeless/kubeless/pkg/functions"\nfunc Foo(event functions.Event, context functions.Context) (string, error) {\nfor{\n}\nreturn "", nil\n}' > $(TMPDIR)/hello-loop.js
-	kubeless function deploy timeout-go --runtime go1.14 --handler helloget.Foo  --from-file $(TMPDIR)/hello-loop.js --timeout 4
+	kubeless function deploy timeout-go --runtime go1.17 --handler helloget.Foo  --from-file $(TMPDIR)/hello-loop.js --timeout 4
 	rm -rf $(TMPDIR)
 
 timeout-go-verify:
@@ -68,7 +56,7 @@ timeout-go-verify:
 	echo $(MSG) | egrep Request.timeout.exceeded
 
 get-go-deps:
-	kubeless function deploy get-go-deps --runtime go1.14 --handler helloget.Hello --from-file examples/hellowithdeps.go --dependencies examples/go.mod
+	kubeless function deploy get-go-deps --runtime go1.17 --handler helloget.Hello --from-file examples/hellowithdeps.go --dependencies examples/go.mod
 
 get-go-deps-verify:
 	kubectl rollout status deployment/get-go-deps && sleep 2
@@ -76,7 +64,7 @@ get-go-deps-verify:
 	kubectl logs --tail=1000 -l function=get-go-deps | grep -q 'level=info msg=.*hello.*world'
 
 post-go:
-	kubeless function deploy post-go --runtime go1.14 --handler hellowithdata.Handler --from-file examples/hellowithdata.go
+	kubeless function deploy post-go --runtime go1.17 --handler hellowithdata.Handler --from-file examples/hellowithdata.go
 
 post-go-verify:
 	kubectl rollout status deployment/post-go && sleep 2

--- a/stable/golang/Makefile
+++ b/stable/golang/Makefile
@@ -6,13 +6,13 @@ init-image-1.14:
 	docker build --no-cache -f Dockerfile.1.14.init -t kubeless/go-init:1.14 .
 
 init-image-1.17:
-	docker build --no-cache -f Dockerfile.1.17.init -t kubeless/go-init:1.17 .
+	docker build --no-cache -f Dockerfile.1.17.init -t dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go-init:iwo-0.0.10 .
 
-init-image: init-image-1.13 init-image-1.14
+init-image: init-image-1.17
 
 # Runtime images
 runtime-image-1.17:
-	docker build --no-cache -f Dockerfile -t kubeless/go:1.17 .
+	docker build --no-cache -f Dockerfile -t dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go:iwo-0.0.10 .
 
 runtime-image: runtime-image-1.17
 
@@ -20,15 +20,18 @@ runtime-image: runtime-image-1.17
 push-init-1.13:
 	docker push kubeless/go-init:1.13
 
-push-init-1.14:
-	docker push kubeless/go-init:1.14
+push-init-1.17:
+	docker push dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go-init:iwo-0.0.10
 
-push-init: push-init-1.13 push-init-1.14
+push-init: push-init-1.17
 
 push-runtime-1.14:
 	docker push kubeless/go:1.14
 
-push-runtime: push-runtime-1.14
+push-runtime-1.17:
+    docker push dockerhub.cisco.com/cspg-docker/andromeda/kubeless/go:iwo-0.0.10
+
+push-runtime: push-runtime-1.17
 
 # Mandatory jobs
 build-all: init-image runtime-image

--- a/stable/golang/Makefile
+++ b/stable/golang/Makefile
@@ -5,13 +5,16 @@ init-image-1.13:
 init-image-1.14:
 	docker build --no-cache -f Dockerfile.1.14.init -t kubeless/go-init:1.14 .
 
+init-image-1.17:
+	docker build --no-cache -f Dockerfile.1.17.init -t kubeless/go-init:1.17 .
+
 init-image: init-image-1.13 init-image-1.14
 
 # Runtime images
-runtime-image-1.14:
-	docker build --no-cache -f Dockerfile -t kubeless/go:1.14 .
+runtime-image-1.17:
+	docker build --no-cache -f Dockerfile -t kubeless/go:1.17 .
 
-runtime-image: runtime-image-1.14
+runtime-image: runtime-image-1.17
 
 # Push images
 push-init-1.13:

--- a/stable/golang/compile-function.sh
+++ b/stable/golang/compile-function.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-GO_VERSION="1.14"
+GO_VERSION="1.17"
 
 set -e
 
@@ -16,4 +16,4 @@ sed "s/<<FUNCTION>>/${KUBELESS_FUNC_NAME}/g" /server/kubeless.go.tpl > /server/k
 cd /server
 
 # Build the function and redirect stdout & stderr from the compilation step to the k8s output log
-GOOS=linux GOARCH=amd64 go build -o $KUBELESS_INSTALL_VOLUME/server . > /dev/termination-log 2>&1
+GOOS=linux GOARCH=amd64 go build -mod=mod -o $KUBELESS_INSTALL_VOLUME/server . > /dev/termination-log 2>&1

--- a/stable/golang/server/function/go.mod
+++ b/stable/golang/server/function/go.mod
@@ -1,3 +1,3 @@
 module function
 
-go 1.14
+go 1.17

--- a/stable/golang/server/go.mod
+++ b/stable/golang/server/go.mod
@@ -1,9 +1,9 @@
 module github.com/kubeless/runtimes/golang
 
-go 1.14
+go 1.17
 
 replace kubeless => ./function
 
 require (
-	github.com/kubeless/kubeless v1.0.7
+	github.com/kubeless/kubeless v1.0.8
 )

--- a/stable/python/Dockerfile.3.8
+++ b/stable/python/Dockerfile.3.8
@@ -1,4 +1,4 @@
-FROM bitnami/minideb-runtimes:stretch
+FROM bitnami/minideb:stretch
 
 # Install required system packages and dependencies
 RUN install_packages build-essential ca-certificates curl git libbz2-1.0 libc6 libffi6 libncurses5 libreadline7 libsqlite3-0 libssl1.1 libtinfo5 pkg-config unzip wget zlib1g


### PR DESCRIPTION
**Issue Ref**:  https://github.com/kubeless/kubeless/issues/1243
 
**Description**: 
Kubeless uses bitnami/minideb:jessie as it's base for a number of components. Minideb is a slimmed down packaging of upstream Debian and as such they provide no additional security patching beyond what's provided by Debian upstream. Debian Jessie was EOL as of Jan 2020 and no longer receives security updates.

As a result the containers based on minideb:jessie are growing a steadily longer list of critical CVE. The recommended action would be to rebase on a supported version of minideb/debian. Stretch is an option for LTS support until 2022 and is well supported by the minideb project.

Here is an example of a current scan on function-controller:latest performed by grype. All of the other core framework components using minideb:jessie have similar results.

✔ Vulnerability DB [no update available]
✔ Cataloged packages [78 packages]
✔ Scanned image [202 vulnerabilities]

NAME               INSTALLED              FIXED-IN     VULNERABILITY     SEVERITY   
apt                1.0.9.8.6                           CVE-2011-3374     Negligible  
bash               4.3-11+deb8u2                       CVE-2019-18276    Negligible  
bsdutils           1:2.25.2-6                          CVE-2017-2616     Medium      
bsdutils           1:2.25.2-6             (won't fix)  CVE-2016-5011     Medium      
bsdutils           1:2.25.2-6                          CVE-2015-5224     Negligible  
bsdutils           1:2.25.2-6                          CVE-2015-5218     Negligible  
bsdutils           1:2.25.2-6             (won't fix)  CVE-2016-2779     High        
coreutils          8.23-4                 (won't fix)  CVE-2016-2781     Low         
coreutils          8.23-4                              CVE-2017-18018    Negligible  
dpkg               1.17.27                             CVE-2017-8283     Negligible  
gcc-4.9-base       4.9.2-10+deb8u2        (won't fix)  CVE-2018-12886    Medium      
gcc-4.9-base       4.9.2-10+deb8u2        (won't fix)  CVE-2015-5276     Medium      
gcc-4.9-base       4.9.2-10+deb8u2        (won't fix)  CVE-2017-11671    Low         
gnupg              1.4.18-7+deb8u5                     CVE-2018-6829     Negligible  
gnupg              1.4.18-7+deb8u5        (won't fix)  CVE-2019-14855    Low         
gpgv               1.4.18-7+deb8u5                     CVE-2018-6829     Negligible  
gpgv               1.4.18-7+deb8u5        (won't fix)  CVE-2019-14855    Low         
libapt-pkg4.12     1.0.9.8.6                           CVE-2011-3374     Negligible  
libaudit-common    1:2.4-1                             CVE-2015-5186     Negligible  
libaudit1          1:2.4-1+b1                          CVE-2015-5186     Negligible  
libblkid1          2.25.2-6                            CVE-2017-2616     Medium      
libblkid1          2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
libblkid1          2.25.2-6                            CVE-2015-5224     Negligible  
libblkid1          2.25.2-6                            CVE-2015-5218     Negligible  
libblkid1          2.25.2-6               (won't fix)  CVE-2016-2779     High        
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2009-5155     Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2018-6485     High        
libc-bin           2.19-18+deb8u10                     CVE-2019-9192     Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-1000408  High        
libc-bin           2.19-18+deb8u10                     CVE-2019-1010023  Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2019-1010024  Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2019-1010025  Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-15671    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-1000409  Medium      
libc-bin           2.19-18+deb8u10                     CVE-2015-8985     Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2018-20796    Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-15804    Low         
libc-bin           2.19-18+deb8u10                     CVE-2019-6488     Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2019-7309     Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2010-4052     Negligible  
libc-bin           2.19-18+deb8u10                     CVE-2010-4051     Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2020-10029    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-12133    Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-12132    Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2015-5180     Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-16997    High        
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2018-1000001  High        
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2019-9169     High        
libc-bin           2.19-18+deb8u10                     CVE-2010-4756     Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2017-15670    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2014-9761     High        
libc-bin           2.19-18+deb8u10                     CVE-2019-1010022  Negligible  
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2016-10228    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2018-11236    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2018-11237    Low         
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2016-10739    Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2020-1751     Medium      
libc-bin           2.19-18+deb8u10        (won't fix)  CVE-2020-1752     Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2009-5155     Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2018-6485     High        
libc6              2.19-18+deb8u10                     CVE-2019-9192     Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-1000408  High        
libc6              2.19-18+deb8u10                     CVE-2019-1010023  Negligible  
libc6              2.19-18+deb8u10                     CVE-2019-1010024  Negligible  
libc6              2.19-18+deb8u10                     CVE-2019-1010025  Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-15671    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-1000409  Medium      
libc6              2.19-18+deb8u10                     CVE-2015-8985     Negligible  
libc6              2.19-18+deb8u10                     CVE-2018-20796    Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-15804    Low         
libc6              2.19-18+deb8u10                     CVE-2019-6488     Negligible  
libc6              2.19-18+deb8u10                     CVE-2019-7309     Negligible  
libc6              2.19-18+deb8u10                     CVE-2010-4052     Negligible  
libc6              2.19-18+deb8u10                     CVE-2010-4051     Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2020-10029    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-12133    Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-12132    Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2015-5180     Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-16997    High        
libc6              2.19-18+deb8u10        (won't fix)  CVE-2018-1000001  High        
libc6              2.19-18+deb8u10        (won't fix)  CVE-2019-9169     High        
libc6              2.19-18+deb8u10                     CVE-2010-4756     Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2017-15670    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2014-9761     High        
libc6              2.19-18+deb8u10                     CVE-2019-1010022  Negligible  
libc6              2.19-18+deb8u10        (won't fix)  CVE-2016-10228    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2018-11236    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2018-11237    Low         
libc6              2.19-18+deb8u10        (won't fix)  CVE-2016-10739    Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2020-1751     Medium      
libc6              2.19-18+deb8u10        (won't fix)  CVE-2020-1752     Low         
libgcc1            1:4.9.2-10+deb8u2      (won't fix)  CVE-2018-12886    Medium      
libgcc1            1:4.9.2-10+deb8u2      (won't fix)  CVE-2015-5276     Medium      
libgcc1            1:4.9.2-10+deb8u2      (won't fix)  CVE-2017-11671    Low         
libgcrypt20        1.6.3-2+deb8u8                      CVE-2018-6829     Negligible  
libmount1          2.25.2-6                            CVE-2017-2616     Medium      
libmount1          2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
libmount1          2.25.2-6                            CVE-2015-5224     Negligible  
libmount1          2.25.2-6                            CVE-2015-5218     Negligible  
libmount1          2.25.2-6               (won't fix)  CVE-2016-2779     High        
libncurses5        5.9+20140913-1+deb8u3  (won't fix)  CVE-2018-19211    Low         
libncurses5        5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17594    Low         
libncurses5        5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17595    Low         
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2017-7245     Negligible  
libpcre3           2:8.35-3.3+deb8u4                   CVE-2017-11164    Negligible  
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2017-7186     Medium      
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2017-7246     Negligible  
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2017-7244     Medium      
libpcre3           2:8.35-3.3+deb8u4                   CVE-2017-16231    Negligible  
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2015-3217     Medium      
libpcre3           2:8.35-3.3+deb8u4      (won't fix)  CVE-2020-14155    Medium      
libpcre3           2:8.35-3.3+deb8u4                   CVE-2019-20838    Negligible  
libsmartcols1      2.25.2-6                            CVE-2017-2616     Medium      
libsmartcols1      2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
libsmartcols1      2.25.2-6                            CVE-2015-5224     Negligible  
libsmartcols1      2.25.2-6                            CVE-2015-5218     Negligible  
libsmartcols1      2.25.2-6               (won't fix)  CVE-2016-2779     High        
libssl1.0.0        1.0.1t-1+deb8u12                    CVE-2007-6755     Negligible  
libssl1.0.0        1.0.1t-1+deb8u12                    CVE-2010-0928     Negligible  
libssl1.0.0        1.0.1t-1+deb8u12       (won't fix)  CVE-2018-0734     Medium      
libstdc++6         4.9.2-10+deb8u2        (won't fix)  CVE-2018-12886    Medium      
libstdc++6         4.9.2-10+deb8u2        (won't fix)  CVE-2015-5276     Medium      
libstdc++6         4.9.2-10+deb8u2        (won't fix)  CVE-2017-11671    Low         
libsystemd0        215-17+deb8u13         (won't fix)  CVE-2018-16888    Low         
libsystemd0        215-17+deb8u13         (won't fix)  CVE-2018-6954     Low         
libsystemd0        215-17+deb8u13                      CVE-2013-4392     Negligible  
libsystemd0        215-17+deb8u13                      CVE-2019-20386    Negligible  
libsystemd0        215-17+deb8u13                      CVE-2020-13776    Negligible  
libtinfo5          5.9+20140913-1+deb8u3  (won't fix)  CVE-2018-19211    Low         
libtinfo5          5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17594    Low         
libtinfo5          5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17595    Low         
libuuid1           2.25.2-6                            CVE-2017-2616     Medium      
libuuid1           2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
libuuid1           2.25.2-6                            CVE-2015-5224     Negligible  
libuuid1           2.25.2-6                            CVE-2015-5218     Negligible  
libuuid1           2.25.2-6               (won't fix)  CVE-2016-2779     High        
login              1:4.2-3+deb8u4                      CVE-2007-5686     Negligible  
login              1:4.2-3+deb8u4         (won't fix)  CVE-2017-12424    High        
login              1:4.2-3+deb8u4                      CVE-2013-4235     Negligible  
login              1:4.2-3+deb8u4                      CVE-2019-19882    Negligible  
login              1:4.2-3+deb8u4         (won't fix)  CVE-2018-7169     Low         
mount              2.25.2-6                            CVE-2017-2616     Medium      
mount              2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
mount              2.25.2-6                            CVE-2015-5224     Negligible  
mount              2.25.2-6                            CVE-2015-5218     Negligible  
mount              2.25.2-6               (won't fix)  CVE-2016-2779     High        
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2009-5155     Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2018-6485     High        
multiarch-support  2.19-18+deb8u10                     CVE-2019-9192     Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-1000408  High        
multiarch-support  2.19-18+deb8u10                     CVE-2019-1010023  Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2019-1010024  Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2019-1010025  Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-15671    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-1000409  Medium      
multiarch-support  2.19-18+deb8u10                     CVE-2015-8985     Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2018-20796    Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-15804    Low         
multiarch-support  2.19-18+deb8u10                     CVE-2019-6488     Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2019-7309     Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2010-4052     Negligible  
multiarch-support  2.19-18+deb8u10                     CVE-2010-4051     Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2020-10029    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-12133    Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-12132    Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2015-5180     Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-16997    High        
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2018-1000001  High        
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2019-9169     High        
multiarch-support  2.19-18+deb8u10                     CVE-2010-4756     Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2017-15670    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2014-9761     High        
multiarch-support  2.19-18+deb8u10                     CVE-2019-1010022  Negligible  
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2016-10228    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2018-11236    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2018-11237    Low         
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2016-10739    Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2020-1751     Medium      
multiarch-support  2.19-18+deb8u10        (won't fix)  CVE-2020-1752     Low         
ncurses-base       5.9+20140913-1+deb8u3  (won't fix)  CVE-2018-19211    Low         
ncurses-base       5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17594    Low         
ncurses-base       5.9+20140913-1+deb8u3  (won't fix)  CVE-2019-17595    Low         
openssl            1.0.1t-1+deb8u12                    CVE-2007-6755     Negligible  
openssl            1.0.1t-1+deb8u12                    CVE-2010-0928     Negligible  
openssl            1.0.1t-1+deb8u12       (won't fix)  CVE-2018-0734     Medium      
passwd             1:4.2-3+deb8u4                      CVE-2007-5686     Negligible  
passwd             1:4.2-3+deb8u4         (won't fix)  CVE-2017-12424    High        
passwd             1:4.2-3+deb8u4                      CVE-2013-4235     Negligible  
passwd             1:4.2-3+deb8u4                      CVE-2019-19882    Negligible  
passwd             1:4.2-3+deb8u4         (won't fix)  CVE-2018-7169     Low         
perl-base          5.20.2-3+deb8u12       (won't fix)  CVE-2018-6797     High        
perl-base          5.20.2-3+deb8u12                    CVE-2011-4116     Negligible  
perl-base          5.20.2-3+deb8u12                    CVE-2020-10878    High        
perl-base          5.20.2-3+deb8u12                    CVE-2020-12723    Medium      
perl-base          5.20.2-3+deb8u12                    CVE-2020-10543    Medium      
tar                1.27.1-2+deb8u2                     CVE-2005-2541     Negligible  
tar                1.27.1-2+deb8u2                     CVE-2019-9923     Negligible  
util-linux         2.25.2-6                            CVE-2017-2616     Medium      
util-linux         2.25.2-6               (won't fix)  CVE-2016-5011     Medium      
util-linux         2.25.2-6                            CVE-2015-5224     Negligible  
util-linux         2.25.2-6                            CVE-2015-5218     Negligible  
util-linux         2.25.2-6               (won't fix)  CVE-2016-2779     High  

[PR Description]
In this PR we have changed based image to get latest security fixes.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [X] Docs
